### PR TITLE
abweichender Mitgliedsbeitrag

### DIFF
--- a/Beitragsordnung.md
+++ b/Beitragsordnung.md
@@ -11,7 +11,9 @@
  
  (4) Der Mitgliedsbeitrag für Personen unter 16 Jahren beträgt **2,56 Euro**.
  
- (5) Erhöhter Beitrag: Es ist den Migliedern freigestellt, den Beitrag über den in (1) und (2) genannten monatlichen Beitrag zu erhöhen. Mehreinzahlungen werden als erhöhter Beitrag aufgefasst. 
+ (5) Erhöhter Beitrag: Es ist den Migliedern freigestellt, den Beitrag über den in (1) und (2) genannten monatlichen Beitrag zu erhöhen. Mehreinzahlungen werden als erhöhter Beitrag aufgefasst.
+
+ (6) Der Vorstand kann in begründeten Einzelfällen über einen abweichenden Mitgliedsbeitrag entscheiden.
 
  ## § 2 Fälligkeit
   Der Mitgliedsbeitrag wird jeweils zum 1. des Monats bzw. mit der Annahme des Aufnahmeantrags fällig.

--- a/Beitragsordnung.md
+++ b/Beitragsordnung.md
@@ -1,34 +1,39 @@
-# Beitragsordnung 
+# Beitragsordnung
 
+## § 1 Höhe der Beiträge (gestaffelt)
 
- ## §1  Höhe der Beiträge (gestaffelt)
- 
- (1) Der Mitgliedsbeitrag beträgt **23,42 Euro** pro Monat.
- 
- (2) Der Mitgliedsbeitrag für Studierende beträgt **13,37 Euro** pro Monat. Er verlangt die Vorlage einer Studienbescheinigung.
- 
- (3) Der ermäßigte Mitgliedsbeitrag beträgt **9 Euro** pro Monat. Die Ermäßigung gilt für Schüler, Auszubildende und Arbeitslose. Er Verlangt die Vorlage eines schriflichen Nachweises. Der Ermäßigte Beitrag ist in weiteren Fällen nur durch begründete Anfrage zu erwerben. Der Vorstand entscheidet über die Annahme dieser Begründung.
- 
- (4) Der Mitgliedsbeitrag für Personen unter 16 Jahren beträgt **2,56 Euro**.
- 
- (5) Erhöhter Beitrag: Es ist den Migliedern freigestellt, den Beitrag über den in (1) und (2) genannten monatlichen Beitrag zu erhöhen. Mehreinzahlungen werden als erhöhter Beitrag aufgefasst.
+(1) Der Mitgliedsbeitrag beträgt **23,42 Euro** pro Monat.
 
- (6) Der Vorstand kann in begründeten Einzelfällen über einen abweichenden Mitgliedsbeitrag entscheiden.
+(2) Der Mitgliedsbeitrag für Studierende beträgt **13,37 Euro** pro Monat. Er verlangt die Vorlage einer Studienbescheinigung.
 
- ## § 2 Fälligkeit
-  Der Mitgliedsbeitrag wird jeweils zum 1. des Monats bzw. mit der Annahme des Aufnahmeantrags fällig.
- 
- ## § 3 Zahlungsweise
- 
- (1) Die Zahlung des Beitrages erfolgt monatlich per Überweisung auf das Konto des CCCP e.V. Es wird empfohlen, einen Dauerauftrag einzurichten.
- 
- (2) Alternativ zu Abs. (1) kann nach Absprache eine Barzahlung an den Kassenwart erfolgen.
- ## $ 4 Säumnis
- Im Säumnisfall wird das Mitglied nach dreimonatigem Ausbleiben des Beitrags gemahnt. Zahlt ein Mitglied trotz zweifacher Mahnung (in Textform) oder länger als drei Monate den Beitrag nicht, so gilt nach Ablauf eines Monates nach der zweiten Mahnung die Nichtzahlung als Austritt. In der zweiten Mahnung ist auf die Folgen der Nichtzahlung hinzuweisen. 
- 
- ## § 5  Aufnahmegebühren
-  Aufnahmegebühren werden nicht erhoben.
- ## § 6  Erstattungen
-  Eine Erstattung von Mitgliedsbeiträgen findet nicht statt.
+(3) Der ermäßigte Mitgliedsbeitrag beträgt **9 Euro** pro Monat. Die Ermäßigung gilt für Schüler, Auszubildende und Arbeitslose. Er Verlangt die Vorlage eines schriflichen Nachweises. Der Ermäßigte Beitrag ist in weiteren Fällen nur durch begründete Anfrage zu erwerben. Der Vorstand entscheidet über die Annahme dieser Begründung.
+
+(4) Der Mitgliedsbeitrag für Personen unter 16 Jahren beträgt **2,56 Euro**.
+
+(5) Erhöhter Beitrag: Es ist den Migliedern freigestellt, den Beitrag über den in (1) und (2) genannten monatlichen Beitrag zu erhöhen. Mehreinzahlungen werden als erhöhter Beitrag aufgefasst.
+
+(6) Der Vorstand kann in begründeten Einzelfällen über einen abweichenden Mitgliedsbeitrag entscheiden.
+
+## § 2 Fälligkeit
+
+Der Mitgliedsbeitrag wird jeweils zum 1. des Monats bzw. mit der Annahme des Aufnahmeantrags fällig.
+
+## § 3 Zahlungsweise
+
+(1) Die Zahlung des Beitrages erfolgt monatlich per Überweisung auf das Konto des CCCP e.V. Es wird empfohlen, einen Dauerauftrag einzurichten.
+
+(2) Alternativ zu Abs. (1) kann nach Absprache eine Barzahlung an den Kassenwart erfolgen.
+
+## § 4 Säumnis
+
+Im Säumnisfall wird das Mitglied nach dreimonatigem Ausbleiben des Beitrags gemahnt. Zahlt ein Mitglied trotz zweifacher Mahnung (in Textform) oder länger als drei Monate den Beitrag nicht, so gilt nach Ablauf eines Monates nach der zweiten Mahnung die Nichtzahlung als Austritt. In der zweiten Mahnung ist auf die Folgen der Nichtzahlung hinzuweisen.
+
+## § 5 Aufnahmegebühren
+
+Aufnahmegebühren werden nicht erhoben.
+
+## § 6 Erstattungen
+
+Eine Erstattung von Mitgliedsbeiträgen findet nicht statt.
 
 `issue: hier kommt vermutlich mehr Rechts-Foo hin`


### PR DESCRIPTION
Weil wir darüber diskutiert haben was mit abweichenden Beiträgen und Entlastung des Vorstands passieren kann,
würde ich dem Vorstand explizit erlauben in Einzelfällen den Beitrag individuell festzulegen.
Das kann dann auch genutzt werden um besonders Reiche dazu zu drängen doch etwas mehr zu zahlen.