### PR TITLE
Eher kleinere Überarbeitungen der Satzung

### DIFF
--- a/Satzung.md
+++ b/Satzung.md
@@ -65,7 +65,7 @@ dem Schatzmeister.
 
 Diese werden von der Mitgliedsversammlung gewählt und sind Vorstand im Sinne des § 26 BGB. Sie vertreten den Verein `issue: /* jeweils allein */` gerichtlich und außergerichtlich.
 
-(4) Darüber hinaus kann die Mitgliedsversammlung einen Schatzmeister sowie bis zu drei Beisitzer als stimmberechtigte Vorstandsmitglieder wählen. Der Vorstand fasst seine Beschlüsse mit einfacher Mehrheit der abgegebenen Stimmen, Stimmenthaltungen werden nicht mitgezählt. Der Vorstand regelt seine Geschäftsverteilung durch gesonderten Vorstandsbeschluss und darf einzelnen Vereinsmitgliedern Vollmachten zur Vertretung des Vereins in bestimmten Angelegenheiten erteilen. Vorstandssitzungen werden vom 1. oder 2. Vorsitzenden mit einer Ladungfrist von drei Tagen schriftlich einberufen.
+(4) Darüber hinaus kann die Mitgliedsversammlung bis zu drei Beisitzer als stimmberechtigte Vorstandsmitglieder wählen. Der Vorstand fasst seine Beschlüsse mit einfacher Mehrheit der abgegebenen Stimmen, Stimmenthaltungen werden nicht mitgezählt. Der Vorstand regelt seine Geschäftsverteilung durch gesonderten Vorstandsbeschluss und darf einzelnen Vereinsmitgliedern Vollmachten zur Vertretung des Vereins in bestimmten Angelegenheiten erteilen. Vorstandssitzungen werden vom 1. oder 2. Vorsitzenden mit einer Ladungfrist von drei Tagen schriftlich einberufen.
 
 (5) Der Vorstand kann einzelne Vereinsmitglieder `issue: /* oder Person */` als Berater hinzuziehen, diese haben dann kein Stimmrecht im Vorstand. Der Einberufende kann bestimmen, dass die Sitzung in fernmündlicher oder mittels sonstiger Nachrichtenübermittlung geschieht. Über die Beschlüsse ist eine Niederschrift anzufertigen, die allen Vorstandmitgliedern binnen einer Woche nach der Sitzung zuzustellen ist.
 

--- a/Satzung.md
+++ b/Satzung.md
@@ -34,17 +34,16 @@ Errichtet am 10. April 2019 in Potsdam
 
 ## § 3 Rechte und Pflichten der Mitglieder
 
-(1) Alle Vereinsmitglieder haben die Pflicht
+(1) Alle Vereinsmitglieder haben die Pflicht,
 
 * jederzeit die Interessen des Vereins zu wahren,
 * festgesetzte Umlagen und Beiträge unverzüglich bei Fälligkeit zu zahlen,
 * dem Vorstand laufend und unverzüglich ihre aktuelle Anschrift mitzuteilen und
 * auf gesonderte Ladung durch den Vorstand hin an Vorstandssitzungen und Mitgliedsversammlungen teilzunehmen.
 
-(2) Alle Vereinsmitglieder haben das Recht
+(2) Alle Vereinsmitglieder haben das Recht, an der Mitgliedsversammlung teilzunehmen und dort abzustimmen. Juristische Personen nehmen durch ihre gesetzlichen Vertreter teil und üben durch diese ihre Mitgliedschaftsrechte aus.
 
-* an der Mitgliedsversammlung teilzunehmen und dort abzustimmen. Juristische Personen nehmen durch ihre gesetzlichen Vertreter teil und üben durch diese ihre Mitgliedschaftsrechte aus.
-* vom Vorstand `issue: quorum?` unter Nennung gewünschter Tagesordnungspunkte und gegebenenfalls abzustimmender Beschlussvorlagen die Einberufung einer Mitgliedsversammlung zu verlangen, die binnen vier Wochen nach Eingang beim Vorstand stattzufinden hat.
+(3) Alle Vereinsmitglieder haben das Recht, vom Vorstand `issue: quorum?` unter Nennung gewünschter Tagesordnungspunkte und gegebenenfalls abzustimmender Beschlussvorlagen die Einberufung einer Mitgliedsversammlung zu verlangen, die binnen vier Wochen nach Eingang beim Vorstand stattzufinden hat.
 
 
 ## § 4 Organe

--- a/Satzung.md
+++ b/Satzung.md
@@ -57,11 +57,9 @@ Errichtet am 10. April 2019 in Potsdam
 
 (3) Der Vorstand besteht aus
 
-dem 1. Vorsitzenden und
-
-dem 2. Vorsitzenden und
-
-dem Schatzmeister.
+* dem 1. Vorsitzenden und
+* dem 2. Vorsitzenden und
+* dem Schatzmeister.
 
 Diese werden von der Mitgliedsversammlung gewählt und sind Vorstand im Sinne des § 26 BGB. Sie vertreten den Verein `issue: /* jeweils allein */` gerichtlich und außergerichtlich.
 

--- a/Satzung.md
+++ b/Satzung.md
@@ -23,10 +23,10 @@ Errichtet am 10. April 2019 in Potsdam
 
 (2) Die Mitgliedschaft endet:
 
-* durch schriftliche Austrittserklärung gegenüber einem Vorstandsmitglied,
-* bei natürlichen Personen durch deren Tod,
-* bei juristischen Personen durch Löschung, Auflösung, Liquidation, Eröffnung des Insolvenzverfahrens, Fusion, Rechtsformänderung, wesensveränderndem Eigentümerwechsel oder sonstiger Beendigung der rechtlichen Existenz oder
-* durch Ausschluss aus dem Verein.
+1. durch schriftliche Austrittserklärung gegenüber einem Vorstandsmitglied,
+1. bei natürlichen Personen durch deren Tod,
+1. bei juristischen Personen durch Löschung, Auflösung, Liquidation, Eröffnung des Insolvenzverfahrens, Fusion, Rechtsformänderung, wesensveränderndem Eigentümerwechsel oder sonstiger Beendigung der rechtlichen Existenz oder
+1. durch Ausschluss aus dem Verein.
 
 (3) Der Vorstand kann Mitglieder wegen vereinsschädigenden Verhaltens sowie wegen Verstoßes gegen Verpflichtungen gemäß § 3 aus dem Verein ausschließen. Der Ausschluss ist an die letzte mitgeteilte Anschrift des betreffenden Mitglieds mitzuteilen und ist zum Zeitpunkt der Absendung wirksam. Dem Ausgeschlossenen steht die Berufung bei der nächsten Mitgliedsversammlung offen; diese entscheidet gegebenenfalls über die rückwirkende Unwirksamkeit des Ausschlusses.
 
@@ -36,10 +36,10 @@ Errichtet am 10. April 2019 in Potsdam
 
 (1) Alle Vereinsmitglieder haben die Pflicht,
 
-* jederzeit die Interessen des Vereins zu wahren,
-* festgesetzte Umlagen und Beiträge unverzüglich bei Fälligkeit zu zahlen,
-* dem Vorstand laufend und unverzüglich ihre aktuelle Anschrift mitzuteilen und
-* auf gesonderte Ladung durch den Vorstand hin an Vorstandssitzungen und Mitgliedsversammlungen teilzunehmen.
+1. jederzeit die Interessen des Vereins zu wahren,
+1. festgesetzte Umlagen und Beiträge unverzüglich bei Fälligkeit zu zahlen,
+1. dem Vorstand laufend und unverzüglich ihre aktuelle Anschrift mitzuteilen und
+1. auf gesonderte Ladung durch den Vorstand hin an Vorstandssitzungen und Mitgliedsversammlungen teilzunehmen.
 
 (2) Alle Vereinsmitglieder haben das Recht, an der Mitgliedsversammlung teilzunehmen und dort abzustimmen. Juristische Personen nehmen durch ihre gesetzlichen Vertreter teil und üben durch diese ihre Mitgliedschaftsrechte aus.
 

--- a/Satzung.md
+++ b/Satzung.md
@@ -53,7 +53,7 @@ Errichtet am 10. April 2019 in Potsdam
 * die Mitgliedsversammlung und
 * der Vorstand.
 
-(2) Die Mitgliederversammlung tritt mindestens einmal pro Kalenderjahr zusammen. Die Mitgliedsversammlung wird vom Vorstand mit einer Ladungsfrist von mindestens 14 Tagen und Angabe einer Tagesordnung schriftlich einberufen. `issue: /* Mitgliedsversammlungen finden stets als Präsenzveranstaltung statt. */`  Jedes Mitglied hat eine Stimme. `issue: /* Stimmrechtsübertragungen sind unzulässig und unwirksam. */` Vertreter juristischer Personen haben ihre Vertretungsberechtigung nachzuweisen. Die Mitgliedsversammlung fasst ihre Beschlüsse mit einfacher Mehrheit der abgegebenen Stimmen. Stimmenthaltungen werden nicht mitgezählt. Jede ordnungsgemäß geladene Mitgliedsversammlung ist beschlussfähig. Versammlungsleiter ist der 1. Vorsitzende, der 2. Vorsitzende als sein Vertreter oder ein von der Mitgliedsversammlung zu Beginn zu wählender Versammlungsleiter. Über die Beschlüsse der Mitgliedsversammlung ist eine Niederschrift anzufertigen, die allen Mitgliedern binnen vier Wochen nach der Versammlung zuzustellen ist.
+(2) Die Mitgliedsversammlung tritt mindestens einmal pro Kalenderjahr zusammen. Die Mitgliedsversammlung wird vom Vorstand mit einer Ladungsfrist von mindestens 14 Tagen und Angabe einer Tagesordnung schriftlich einberufen. `issue: /* Mitgliedsversammlungen finden stets als Präsenzveranstaltung statt. */`  Jedes Mitglied hat eine Stimme. `issue: /* Stimmrechtsübertragungen sind unzulässig und unwirksam. */` Vertreter juristischer Personen haben ihre Vertretungsberechtigung nachzuweisen. Die Mitgliedsversammlung fasst ihre Beschlüsse mit einfacher Mehrheit der abgegebenen Stimmen. Stimmenthaltungen werden nicht mitgezählt. Jede ordnungsgemäß geladene Mitgliedsversammlung ist beschlussfähig. Versammlungsleiter ist der 1. Vorsitzende, der 2. Vorsitzende als sein Vertreter oder ein von der Mitgliedsversammlung zu Beginn zu wählender Versammlungsleiter. Über die Beschlüsse der Mitgliedsversammlung ist eine Niederschrift anzufertigen, die allen Mitgliedern binnen vier Wochen nach der Versammlung zuzustellen ist.
 
 (3) Der Vorstand besteht aus
 
@@ -71,7 +71,7 @@ Diese werden von der Mitgliedsversammlung gewählt und sind Vorstand im Sinne de
 
 (6) Die Vorstandsmitglieder bleiben im Amt, bis die Mitgliedsversammlung einen Nachfolger wählt. Dies soll in der Regel nach zweijähriger Amtzeit geschehen; die Wiederwahl ist zulässig. Erklärt ein Beisitzer gegenüber einem Vorstand seinen Rücktritt, so scheidet er damit aus. Erklärt ein 1. oder 2. Vorsitzender gegenüber dem Vorstand seinen Rücktritt `issue: /* oder scheidet aus, oder ist nicht mehr in der Lage, etc */`, so wählt die Mitgliedsversammlung binnen vier Wochen einen Nachfolger.
 
-`issue: /* (7) Ist abwählen durch Mitgliederversammlung, indem ... */`
+`issue: /* (7) Ist abwählen durch Mitgliedsversammlung, indem ... */`
 
 ## § 5 Finanzen
 


### PR DESCRIPTION
Größententeils Formatierungskrams. Ansonsten:
* Auftrennung der Rechte von Mitgliedern in zwei separate Absätze, um die verschiedenen Aspekte zu trennen, und
* Fix: Entfernen des Schatzmeisters aus der Liste der zusätzlichen Vorstandsmitglieder, nachdem er in eine reguläre Vorstandsposition aufgerückt ist