### PR TITLE
Regle Vorstandsaustausch

### DIFF
--- a/Satzung.md
+++ b/Satzung.md
@@ -91,7 +91,7 @@ Diese werden von der Mitgliedsversammlung gewählt und sind Vorstand im Sinne de
 
 (3) Der Vorstand kann einzelne Personen als Berater hinzuziehen, diese haben dann kein Stimmrecht im Vorstand. Die Einberufenen können bestimmen, dass die Sitzung in fernmündlicher oder mittels sonstiger Nachrichtenübermittlung geschieht. Über die Beschlüsse ist eine Niederschrift anzufertigen, die allen Vorstandmitgliedern binnen einer Woche nach der Sitzung zuzustellen ist.
 
-(4) Die Vorstandsmitglieder bleiben im Amt, bis die Mitgliedsversammlung einen Nachfolger wählt. Dies soll in der Regel nach zweijähriger Amtzeit geschehen; die Wiederwahl ist zulässig. Erklärt ein Beisitzer gegenüber einem Vorstand seinen Rücktritt, so scheidet er damit aus. Erklärt ein Vorstandsmitglied gegenüber dem Vorstand seinen Rücktritt, oder scheidet es aus dem Verein aus, oder langfristig an der Ausübung seines Amtes gehindert, so wählt die Mitgliedsversammlung binnen vier Wochen einen Nachfolger.
+(4) Die Vorstandsmitglieder bleiben im Amt, bis die Mitgliedsversammlung einen Nachfolger wählt. Dies soll in der Regel nach zweijähriger Amtzeit geschehen; die Wiederwahl ist zulässig. Erklärt ein Beisitzer gegenüber einem Vorstand seinen Rücktritt, so scheidet er damit aus. Erklärt ein Vorstandsmitglied gegenüber dem Vorstand seinen Rücktritt, scheidet es aus dem Verein aus, oder ist langfristig an der Ausübung seines Amtes gehindert, so wählt die Mitgliedsversammlung binnen vier Wochen einen Nachfolger.
 
 
 

--- a/Satzung.md
+++ b/Satzung.md
@@ -91,7 +91,7 @@ Diese werden von der Mitgliedsversammlung gewählt und sind Vorstand im Sinne de
 
 (3) Der Vorstand kann einzelne Personen als Berater hinzuziehen, diese haben dann kein Stimmrecht im Vorstand. Die Einberufenen können bestimmen, dass die Sitzung in fernmündlicher oder mittels sonstiger Nachrichtenübermittlung geschieht. Über die Beschlüsse ist eine Niederschrift anzufertigen, die allen Vorstandmitgliedern binnen einer Woche nach der Sitzung zuzustellen ist.
 
-(4) Die Vorstandsmitglieder bleiben im Amt, bis die Mitgliedsversammlung einen Nachfolger wählt. Dies soll in der Regel nach zweijähriger Amtzeit geschehen; die Wiederwahl ist zulässig. Erklärt ein Beisitzer gegenüber einem Vorstand seinen Rücktritt, so scheidet er damit aus. Erklärt ein Vorstandsmitglied gegenüber dem Vorstand seinen Rücktritt, oder scheidet es aus dem Verein aus, oder ist langfristig nicht mehr in der Lage die Geschäfte zu führen, so wählt die Mitgliedsversammlung binnen vier Wochen einen Nachfolger.
+(4) Die Vorstandsmitglieder bleiben im Amt, bis die Mitgliedsversammlung einen Nachfolger wählt. Dies soll in der Regel nach zweijähriger Amtzeit geschehen; die Wiederwahl ist zulässig. Erklärt ein Beisitzer gegenüber einem Vorstand seinen Rücktritt, so scheidet er damit aus. Erklärt ein Vorstandsmitglied gegenüber dem Vorstand seinen Rücktritt, oder scheidet es aus dem Verein aus, oder langfristig an der Ausübung seines Amtes gehindert, so wählt die Mitgliedsversammlung binnen vier Wochen einen Nachfolger.
 
 
 
@@ -118,4 +118,3 @@ Die Auflösung des Vereins geschieht durch Beschluss der Mitgliedsversammlung mi
 ## § 10 Kommunikation
 
 Schriftliche Erklärungen im Sinne dieser Satzung sind handschriftlich unterschriebene Dokumente in Papierform sowie mit geeigneten Mitteln signierte elektronische Dokumente (E-Mail).
-a

--- a/Satzung.md
+++ b/Satzung.md
@@ -91,9 +91,7 @@ Diese werden von der Mitgliedsversammlung gewählt und sind Vorstand im Sinne de
 
 (3) Der Vorstand kann einzelne Personen als Berater hinzuziehen, diese haben dann kein Stimmrecht im Vorstand. Die Einberufenen können bestimmen, dass die Sitzung in fernmündlicher oder mittels sonstiger Nachrichtenübermittlung geschieht. Über die Beschlüsse ist eine Niederschrift anzufertigen, die allen Vorstandmitgliedern binnen einer Woche nach der Sitzung zuzustellen ist.
 
-(4) Die Vorstandsmitglieder bleiben im Amt, bis die Mitgliedsversammlung einen Nachfolger wählt. Dies soll in der Regel nach zweijähriger Amtzeit geschehen; die Wiederwahl ist zulässig. Erklärt ein Beisitzer gegenüber einem Vorstand seinen Rücktritt, so scheidet er damit aus. Erklärt ein 1. oder 2. Vorsitzender gegenüber dem Vorstand seinen Rücktritt `issue: /* oder scheidet aus, oder ist nicht mehr in der Lage, etc */`, so wählt die Mitgliedsversammlung binnen vier Wochen einen Nachfolger.
-
-`issue: /* (5) Ist abwählen durch Mitgliedsversammlung, indem ... */`
+(4) Die Vorstandsmitglieder bleiben im Amt, bis die Mitgliedsversammlung einen Nachfolger wählt. Dies soll in der Regel nach zweijähriger Amtzeit geschehen; die Wiederwahl ist zulässig. Erklärt ein Beisitzer gegenüber einem Vorstand seinen Rücktritt, so scheidet er damit aus. Erklärt ein Vorstandsmitglied gegenüber dem Vorstand seinen Rücktritt, oder scheidet es aus dem Verein aus, oder ist langfristig nicht mehr in der Lage die Geschäfte zu führen, so wählt die Mitgliedsversammlung binnen vier Wochen einen Nachfolger.
 
 
 
@@ -120,3 +118,4 @@ Die Auflösung des Vereins geschieht durch Beschluss der Mitgliedsversammlung mi
 ## § 10 Kommunikation
 
 Schriftliche Erklärungen im Sinne dieser Satzung sind handschriftlich unterschriebene Dokumente in Papierform sowie mit geeigneten Mitteln signierte elektronische Dokumente (E-Mail).
+a

--- a/Satzung.md
+++ b/Satzung.md
@@ -91,7 +91,7 @@ Diese werden von der Mitgliedsversammlung gewählt und sind Vorstand im Sinne de
 
 (3) Der Vorstand kann einzelne Personen als Berater hinzuziehen, diese haben dann kein Stimmrecht im Vorstand. Die Einberufenen können bestimmen, dass die Sitzung in fernmündlicher oder mittels sonstiger Nachrichtenübermittlung geschieht. Über die Beschlüsse ist eine Niederschrift anzufertigen, die allen Vorstandmitgliedern binnen einer Woche nach der Sitzung zuzustellen ist.
 
-(4) Die Vorstandsmitglieder bleiben im Amt, bis die Mitgliedsversammlung einen Nachfolger wählt. Dies soll in der Regel nach zweijähriger Amtzeit geschehen; die Wiederwahl ist zulässig. Erklärt ein Beisitzer gegenüber einem Vorstand seinen Rücktritt, so scheidet er damit aus. Erklärt ein Vorstandsmitglied gegenüber dem Vorstand seinen Rücktritt, scheidet es aus dem Verein aus, oder ist langfristig an der Ausübung seines Amtes gehindert, so wählt die Mitgliedsversammlung binnen vier Wochen einen Nachfolger.
+(4) Die Vorstandsmitglieder bleiben im Amt, bis die Mitgliedsversammlung einen Nachfolger wählt. Dies soll in der Regel nach zweijähriger Amtzeit geschehen; die Wiederwahl ist zulässig. Erklärt ein Beisitzer gegenüber einem Vorstand seinen Rücktritt, so scheidet er damit aus. Erklärt ein Vorstandsmitglied gegenüber dem Vorstand seinen Rücktritt, scheidet es aus dem Verein aus, oder ist langfristig an der Ausübung seines Amtes gehindert, so wählt die Mitgliedsversammlung binnen vier Wochen einen Nachfolger.
 
 
 


### PR DESCRIPTION
Vorstandsmitglieder werden ersetzt durch Neuwahl (kann z.B. durch außerordentliche Mitgliederversammlung getriggert werden).

Neuwahl geschieht z.B. auch bei langfrister Krankheit.

