### PR TITLE
Anwesenheit & Stimmübertragung (see issue #17)

### DIFF
--- a/Satzung.md
+++ b/Satzung.md
@@ -61,9 +61,9 @@ Organe des Vereins sind
 
 (1) Die Mitgliedsversammlung tritt mindestens einmal pro Kalenderjahr zusammen. Die Mitgliedsversammlung wird vom
  Vorstand mit einer Ladungsfrist von mindestens 14 Tagen und Angabe einer Tagesordnung schriftlich einberufen.
- `issue: /* Mitgliedsversammlungen finden stets als Präsenzveranstaltung statt. */` 
+ Mitgliedsversammlungen finden stets als Präsenzveranstaltung statt.
 
-(2) Jedes Mitglied hat eine Stimme. `issue: /* Stimmrechtsübertragungen sind unzulässig und unwirksam. */` Vertreter juristischer Personen haben ihre Vertretungsberechtigung nachzuweisen.
+(2) Jedes Mitglied hat eine Stimme. Stimmrechtsübertragungen sind unzulässig und unwirksam. Vertreter juristischer Personen haben ihre Vertretungsberechtigung nachzuweisen.
 
 (3) Die Mitgliedsversammlung fasst ihre Beschlüsse mit einfacher Mehrheit der abgegebenen Stimmen. Stimmenthaltungen 
  werden nicht mitgezählt.


### PR DESCRIPTION
Aus Anfechtungsvermeidung sollen Beschlüsse klar sein, Vollmachten nicht 1000 fach zu hinterfragen sein.