### PR TITLE
Mitgliedsversammlung → Mitgliederversammlung

### DIFF
--- a/Satzung.md
+++ b/Satzung.md
@@ -28,7 +28,7 @@ Errichtet am 10. April 2019 in Potsdam
 1. bei natürlichen Personen durch deren Tod,
 1. durch Ausschluss aus dem Verein.
 
-(3) Der Vorstand kann Mitglieder wegen vereinsschädigenden Verhaltens sowie wegen Verstoßes gegen Verpflichtungen gemäß § 3 aus dem Verein ausschließen. Der Ausschluss ist an die letzte mitgeteilte Anschrift des betreffenden Mitglieds mitzuteilen und ist zum Zeitpunkt der Absendung wirksam. Dem Ausgeschlossenen steht die Berufung bei der nächsten Mitgliedsversammlung offen; diese entscheidet gegebenenfalls über die rückwirkende Unwirksamkeit des Ausschlusses.
+(3) Der Vorstand kann Mitglieder wegen vereinsschädigenden Verhaltens sowie wegen Verstoßes gegen Verpflichtungen gemäß § 3 aus dem Verein ausschließen. Der Ausschluss ist an die letzte mitgeteilte Anschrift des betreffenden Mitglieds mitzuteilen und ist zum Zeitpunkt der Absendung wirksam. Dem Ausgeschlossenen steht die Berufung bei der nächsten Mitgliederversammlung offen; diese entscheidet gegebenenfalls über die rückwirkende Unwirksamkeit des Ausschlusses.
 
 (4) Innerhalb der ersten drei Monate der Mitgliedschaft ist ein Ausschluss auch ohne Vorliegen von Gründen möglich (Probezeit). Eine Berufung ist hierbei ausgeschlossen.
 
@@ -41,11 +41,11 @@ Errichtet am 10. April 2019 in Potsdam
 1. jederzeit die Interessen des Vereins zu wahren,
 1. festgesetzte Umlagen und Beiträge unverzüglich bei Fälligkeit zu zahlen,
 1. dem Vorstand laufend und unverzüglich ihre aktuelle Anschrift mitzuteilen und
-1. auf gesonderte Ladung durch den Vorstand hin an Vorstandssitzungen und Mitgliedsversammlungen teilzunehmen.
+1. auf gesonderte Ladung durch den Vorstand hin an Vorstandssitzungen und Mitgliederversammlungen teilzunehmen.
 
-(2) Alle Vereinsmitglieder haben das Recht, an der Mitgliedsversammlung teilzunehmen und dort abzustimmen.
+(2) Alle Vereinsmitglieder haben das Recht, an der Mitgliederversammlung teilzunehmen und dort abzustimmen.
 
-(3) Eine Gemeinschaft von mehr als drei Vereinsmitglieder hat das Recht, vom Vorstand unter Nennung gewünschter Tagesordnungspunkte und gegebenenfalls abzustimmender Beschlussvorlagen die Einberufung einer Mitgliedsversammlung zu verlangen. Diese Mitgliedsversammlung hat binnen vier Wochen nach Eingang beim Vorstand stattzufinden.
+(3) Eine Gemeinschaft von mehr als drei Vereinsmitglieder hat das Recht, vom Vorstand unter Nennung gewünschter Tagesordnungspunkte und gegebenenfalls abzustimmender Beschlussvorlagen die Einberufung einer Mitgliederversammlung zu verlangen. Diese Mitgliederversammlung hat binnen vier Wochen nach Eingang beim Vorstand stattzufinden.
 
 
 
@@ -53,28 +53,28 @@ Errichtet am 10. April 2019 in Potsdam
 
 Organe des Vereins sind
 
-* die Mitgliedsversammlung und
+* die Mitgliederversammlung und
 * der Vorstand.
 
 
 
-## § 5 Mitgliedsversammlung
+## § 5 Mitgliederversammlung
 
-(1) Die Mitgliedsversammlung tritt mindestens einmal pro Kalenderjahr zusammen. Die Mitgliedsversammlung wird vom
+(1) Die Mitgliederversammlung tritt mindestens einmal pro Kalenderjahr zusammen. Die Mitgliederversammlung wird vom
  Vorstand mit einer Ladungsfrist von mindestens 14 Tagen und Angabe einer Tagesordnung schriftlich einberufen.
- Mitgliedsversammlungen finden stets als Präsenzveranstaltung statt.
+ Mitgliederversammlungen finden stets als Präsenzveranstaltung statt.
 
 (2) Jedes Mitglied hat eine Stimme. Stimmrechtsübertragungen sind unzulässig und unwirksam.
 
-(3) Die Mitgliedsversammlung fasst ihre Beschlüsse mit einfacher Mehrheit der abgegebenen Stimmen. Stimmenthaltungen 
+(3) Die Mitgliederversammlung fasst ihre Beschlüsse mit einfacher Mehrheit der abgegebenen Stimmen. Stimmenthaltungen 
  werden nicht mitgezählt.
 
-(4) Jede ordnungsgemäß geladene Mitgliedsversammlung ist beschlussfähig.
+(4) Jede ordnungsgemäß geladene Mitgliederversammlung ist beschlussfähig.
 
 (5) Versammlungsleiter ist der 1. Vorsitzende, der 2. Vorsitzende als sein Vertreter oder ein von der
- Mitgliedsversammlung zu Beginn zu wählender Versammlungsleiter.
+ Mitgliederversammlung zu Beginn zu wählender Versammlungsleiter.
 
-(6) Über die Beschlüsse der Mitgliedsversammlung ist eine Niederschrift anzufertigen, die allen Mitgliedern binnen vier
+(6) Über die Beschlüsse der Mitgliederversammlung ist eine Niederschrift anzufertigen, die allen Mitgliedern binnen vier
  Wochen nach der Versammlung zuzustellen ist.
 
 
@@ -87,13 +87,13 @@ Organe des Vereins sind
 * dem 2. Vorsitzenden und
 * dem Schatzmeister.
 
-Diese werden von der Mitgliedsversammlung gewählt und sind Vorstand im Sinne des § 26 BGB. Sie vertreten den Verein jeweils allein gerichtlich und außergerichtlich.
+Diese werden von der Mitgliederversammlung gewählt und sind Vorstand im Sinne des § 26 BGB. Sie vertreten den Verein jeweils allein gerichtlich und außergerichtlich.
 
-(2) Darüber hinaus kann die Mitgliedsversammlung bis zu drei Beisitzer als stimmberechtigte Vorstandsmitglieder wählen. Der Vorstand fasst seine Beschlüsse mit einfacher Mehrheit der abgegebenen Stimmen, Stimmenthaltungen werden nicht mitgezählt. Der Vorstand regelt seine Geschäftsverteilung durch gesonderten Vorstandsbeschluss und darf einzelnen Vereinsmitgliedern Vollmachten zur Vertretung des Vereins in bestimmten Angelegenheiten erteilen. Vorstandssitzungen werden vom 1. oder 2. Vorsitzenden mit einer Ladungfrist von drei Tagen schriftlich einberufen.
+(2) Darüber hinaus kann die Mitgliederversammlung bis zu drei Beisitzer als stimmberechtigte Vorstandsmitglieder wählen. Der Vorstand fasst seine Beschlüsse mit einfacher Mehrheit der abgegebenen Stimmen, Stimmenthaltungen werden nicht mitgezählt. Der Vorstand regelt seine Geschäftsverteilung durch gesonderten Vorstandsbeschluss und darf einzelnen Vereinsmitgliedern Vollmachten zur Vertretung des Vereins in bestimmten Angelegenheiten erteilen. Vorstandssitzungen werden vom 1. oder 2. Vorsitzenden mit einer Ladungfrist von drei Tagen schriftlich einberufen.
 
 (3) Der Vorstand kann einzelne Personen als Berater hinzuziehen, diese haben dann kein Stimmrecht im Vorstand. Die Einberufenen können bestimmen, dass die Sitzung mittels fernmündlicher oder sonstiger Nachrichtenübermittlung geschieht. Über die Beschlüsse ist eine Niederschrift anzufertigen, die allen Vorstandmitgliedern binnen einer Woche nach der Sitzung zuzustellen ist.
 
-(4) Die Vorstandsmitglieder bleiben im Amt, bis die Mitgliedsversammlung einen Nachfolger wählt. Dies soll in der Regel nach zweijähriger Amtzeit geschehen; die Wiederwahl ist zulässig. Erklärt ein Beisitzer gegenüber dem Vorstand seinen Rücktritt, so scheidet er damit aus. Erklärt ein Vorstandsmitglied nach (1) gegenüber dem Vorstand seinen Rücktritt oder scheidet aus dem Verein aus oder ist langfristig an der Ausübung seines Amtes gehindert, so wählt die Mitgliedsversammlung binnen vier Wochen einen Nachfolger.
+(4) Die Vorstandsmitglieder bleiben im Amt, bis die Mitgliederversammlung einen Nachfolger wählt. Dies soll in der Regel nach zweijähriger Amtzeit geschehen; die Wiederwahl ist zulässig. Erklärt ein Beisitzer gegenüber dem Vorstand seinen Rücktritt, so scheidet er damit aus. Erklärt ein Vorstandsmitglied nach (1) gegenüber dem Vorstand seinen Rücktritt oder scheidet aus dem Verein aus oder ist langfristig an der Ausübung seines Amtes gehindert, so wählt die Mitgliederversammlung binnen vier Wochen einen Nachfolger.
 
 
 
@@ -101,22 +101,22 @@ Diese werden von der Mitgliedsversammlung gewählt und sind Vorstand im Sinne de
 
 (1) Der Verein finanziert seine Tätigkeit durch Beiträge, Umlagen und Schenkungen, ferner durch Erlöse aus Veranstaltungen und sonstigen dem Vereinszweck dienenden Maßnahmen. Der Verein ist nicht auf eigenwirtschaftliche Tätigkeit ausgerichtet und soll keine Gewinne erzielen, sondern vielmehr als Idealverein wirken. Entstehende Kosten und Defizite sind durch Beiträge und Umlagen der Mitglieder auszugleichen.
 
-(2) Beitrags- und Umlageverpflichtungen sowie Vorgaben zur Mittelverwendung werden durch vom Vorstand erlassene Ordnungen geregelt. Über die Annahme von Schenkungen entscheidet der Vorstand. Der gesamte Vorstand ist gegenüber der Mitgliedsversammlung für die Finanzen des Vereins verantwortlich und hat dieser mindestens einmal im Kalenderjahr einen Finanzbericht zu erstatten, woraufhin die Mitgliedsversammlung über die Entlastung des Vorstands abzustimmen hat.
+(2) Beitrags- und Umlageverpflichtungen sowie Vorgaben zur Mittelverwendung werden durch vom Vorstand erlassene Ordnungen geregelt. Über die Annahme von Schenkungen entscheidet der Vorstand. Der gesamte Vorstand ist gegenüber der Mitgliederversammlung für die Finanzen des Vereins verantwortlich und hat dieser mindestens einmal im Kalenderjahr einen Finanzbericht zu erstatten, woraufhin die Mitgliederversammlung über die Entlastung des Vorstands abzustimmen hat.
 
 (3) Zur Finanzierung besonderer Vorhaben oder zur Beseitigung finanzieller Schwierigkeiten des Vereins können von den Mitgliedern Umlagen erhoben werden. Über die Notwendigkeit, Höhe und Fälligkeit von Umlagen und den Kreis der zahlungspflichtigen Mitglieder entscheidet die Mitgliederversammlung mit der einfachen Mehrheit der abgegebenen Stimmen. Die Höhe der Umlage darf das Sechsfache des zuletzt festgesetzten monatlichen Mitgliedsbeitrags nicht übersteigen.
 
 
 ## § 8 Satzungsänderungen
 
-(1) Über Änderungen und Ergänzungen dieser Satzung entscheidet die Mitgliedsversammlung mit Dreiviertelmehrheit. Sollten einzelne Bestimmungen dieser Satzung unwirksam sein oder werden, so gelten sie als durch solche wirksame Satzungsbestimmungen ersetzt, die dem Zweck der jeweiligen Bestimmung am nächsten kommen.
+(1) Über Änderungen und Ergänzungen dieser Satzung entscheidet die Mitgliederversammlung mit Dreiviertelmehrheit. Sollten einzelne Bestimmungen dieser Satzung unwirksam sein oder werden, so gelten sie als durch solche wirksame Satzungsbestimmungen ersetzt, die dem Zweck der jeweiligen Bestimmung am nächsten kommen.
 
-(2) Satzungsänderungen, die von Aufsichts-, Gerichts- oder Finanzbehörden aus formalen Gründen verlangt werden, kann der Vorstand von sich aus vornehmen. Diese Satzungsänderungen müssen der nächsten Mitgliedsversammlung mitgeteilt werden.
+(2) Satzungsänderungen, die von Aufsichts-, Gerichts- oder Finanzbehörden aus formalen Gründen verlangt werden, kann der Vorstand von sich aus vornehmen. Diese Satzungsänderungen müssen der nächsten Mitgliederversammlung mitgeteilt werden.
 
 
 
 ## § 9 Auflösung
 
-Die Auflösung des Vereins geschieht durch Beschluss der Mitgliedsversammlung mit Dreiviertelmehrheit. Die Mitgliedsversammlung hat einen Liquidator zu bestellen. Diesbezügliche Bekanntmachungen erfolgen im *elektronischen Bundesanzeiger*. Ein eventueller Liquidationserlös wird nicht an die Vereinsmitglieder ausgeschüttet, sondern kommt einem von der Mitgliedsversammlung mit einfacher Mehrheit zu bestimmenden Zweck oder Empfänger zu. Mangels anderslautenden Beschlusses fällt der Liquidationserlös an das Land Brandenburg.
+Die Auflösung des Vereins geschieht durch Beschluss der Mitgliederversammlung mit Dreiviertelmehrheit. Die Mitgliederversammlung hat einen Liquidator zu bestellen. Diesbezügliche Bekanntmachungen erfolgen im *elektronischen Bundesanzeiger*. Ein eventueller Liquidationserlös wird nicht an die Vereinsmitglieder ausgeschüttet, sondern kommt einem von der Mitgliederversammlung mit einfacher Mehrheit zu bestimmenden Zweck oder Empfänger zu. Mangels anderslautenden Beschlusses fällt der Liquidationserlös an das Land Brandenburg.
 
 
 ## § 10 Kommunikation


### PR DESCRIPTION
[Duden](https://www.duden.de/rechtschreibung/Mitgliederversammlung) und [Wikipedia](https://de.wikipedia.org/wiki/Mitgliederversammlung) nutzen das Wort »Mitgliederversammlung«. Daher würde ich den Satzungstext dahingehend ändern.

Siehe #54.